### PR TITLE
Ensured that jsdom 3.x.x is used

### DIFF
--- a/src/nodejs/package.json
+++ b/src/nodejs/package.json
@@ -9,7 +9,7 @@
     "bin": {"yslow": "./bin/yslow"},
     "repository": {"type": "", "url": ""},
     "dependencies": {
-        "jsdom": ">=0.2.10",
+        "jsdom": "3.x.x",
         "commander": ">=0.2.0"
     },
     "engines": { "node": ">= 0.4.1" }


### PR DESCRIPTION
jsdom >= 4.0.0 only works with io.js, which is why yslow nodejs har reader stopped working